### PR TITLE
Add tags to filter remote access requests

### DIFF
--- a/linux/opt/sage/bin/apply_name_tag.sh
+++ b/linux/opt/sage/bin/apply_name_tag.sh
@@ -17,4 +17,4 @@ NAME=$(echo $PRODUCTS | jq '.ProvisionedProducts[0].Name')
 ACCESS_APPROVED_ROLEID=$(echo $PRODUCTS | jq '.ProvisionedProducts[0].AccessApprovedRoleId')
 /usr/bin/aws ec2 create-tags --region $AWS_REGION \
   --resources $EC2_INSTANCE_ID \
-  --tags Key=Name,Value=$NAME Key=OwnerEmail,Value=$OWNER_EMAIL Key=AccessApprovedCaller,Value=$ACCESS_APPROVED_ROLEID$OIDC_USER_ID
+  --tags Key=Name,Value=$NAME Key=OwnerEmail,Value=$OWNER_EMAIL Key=AccessApprovedCaller,Value=$ACCESS_APPROVED_ROLEID:$OIDC_USER_ID

--- a/linux/opt/sage/bin/apply_name_tag.sh
+++ b/linux/opt/sage/bin/apply_name_tag.sh
@@ -14,6 +14,7 @@ then
   exit 1
 fi
 NAME=$(echo $PRODUCTS | jq '.ProvisionedProducts[0].Name')
+ACCESS_APPROVED_ROLEID=$(echo $PRODUCTS | jq '.ProvisionedProducts[0].AccessApprovedRoleId')
 /usr/bin/aws ec2 create-tags --region $AWS_REGION \
   --resources $EC2_INSTANCE_ID \
-  --tags Key=Name,Value=$NAME Key=OwnerEmail,Value=$OWNER_EMAIL
+  --tags Key=Name,Value=$NAME Key=OwnerEmail,Value=$OWNER_EMAIL Key=AccessApprovedCaller,Value=$ACCESS_APPROVED_ROLEID$OIDC_USER_ID

--- a/linux/opt/sage/bin/make_env_vars_file.sh
+++ b/linux/opt/sage/bin/make_env_vars_file.sh
@@ -32,7 +32,7 @@ extract_tag_value() {
 DEPARTMENT=$(extract_tag_value Department)
 PROJECT=$(extract_tag_value Project)
 PROVISIONING_PRINCIPAL_ARN=$(extract_tag_value 'aws:servicecatalog:provisioningPrincipalArn')
-PRINCIPAL_ID=${PROVISIONING_PRINCIPAL_ARN##*/}
+PRINCIPAL_ID=${PROVISIONING_PRINCIPAL_ARN##*/}  #Immutable Synapse userid derived from assume-role session name
 
 if [[ "$PRINCIPAL_ID" =~ [[:digit:]] ]]; then
   USER_PROFILE_RESPONSE=$(curl -s "https://repo-prod.prod.sagebase.org/repo/v1/userProfile/$PRINCIPAL_ID")
@@ -61,5 +61,6 @@ export ROOT_DISK_ID='$ROOT_DISK_ID'
 export DEPARTMENT=$DEPARTMENT
 export PROJECT=$PROJECT
 export OWNER_EMAIL=$OWNER_EMAIL
+export OIDC_USER_ID=$PRINCIPAL_ID 
 EOM
 chmod +x "$OUTPUT_FILE"


### PR DESCRIPTION
Reads the ServiceCatalogEnduser roleid tag from the instance and appends the Synapse userid to make a new tag.