### PR TITLE
Correct input value to read roleid

### DIFF
--- a/linux/opt/sage/bin/apply_name_tag.sh
+++ b/linux/opt/sage/bin/apply_name_tag.sh
@@ -14,7 +14,8 @@ then
   exit 1
 fi
 NAME=$(echo $PRODUCTS | jq '.ProvisionedProducts[0].Name')
-ACCESS_APPROVED_ROLEID=$(echo $PRODUCTS | jq '.ProvisionedProducts[0].AccessApprovedRoleId')
+PROVISIONED_BY_ARN=$(echo $PRODUCTS | jq -r '.ProvisionedProducts[0].UserArn')
+ACCESS_APPROVED_ROLEID=$(/usr/bin/aws --region $AWS_REGION iam get-role --role-name ${PROVISIONED_BY_ARN##*/} | jq -r '.Role.RoleId')
 /usr/bin/aws ec2 create-tags --region $AWS_REGION \
   --resources $EC2_INSTANCE_ID \
   --tags Key=Name,Value=$NAME Key=OwnerEmail,Value=$OWNER_EMAIL Key=AccessApprovedCaller,Value=$ACCESS_APPROVED_ROLEID:$OIDC_USER_ID


### PR DESCRIPTION
The prior version uses the wrong input to query AWS for the roleid that becomes a tag on an instance, resulting in a tag that reads null. This fix uses the ARN of the user who provisioned the product to query for the roleid. The ARN of the user provisioning the product should always match the provisioningPrincipal tag, I believe
