### PR TITLE
Protect AccessApprovedCaller tag

### DIFF
--- a/linux/opt/sage/bin/apply_name_tag.sh
+++ b/linux/opt/sage/bin/apply_name_tag.sh
@@ -18,4 +18,4 @@ PROVISIONED_BY_ARN=$(echo $PRODUCTS | jq -r '.ProvisionedProducts[0].UserArn')
 ACCESS_APPROVED_ROLEID=$(/usr/bin/aws --region $AWS_REGION iam get-role --role-name ${PROVISIONED_BY_ARN##*/} | jq -r '.Role.RoleId')
 /usr/bin/aws ec2 create-tags --region $AWS_REGION \
   --resources $EC2_INSTANCE_ID \
-  --tags Key=Name,Value=$NAME Key=OwnerEmail,Value=$OWNER_EMAIL Key=AccessApprovedCaller,Value=$ACCESS_APPROVED_ROLEID:$OIDC_USER_ID
+  --tags Key=Name,Value=$NAME Key=OwnerEmail,Value=$OWNER_EMAIL Key='Protected/AccessApprovedCaller',Value=$ACCESS_APPROVED_ROLEID:$OIDC_USER_ID


### PR DESCRIPTION
We want to push the AccessApprovedCaller tag under the Protected/ path so the tag on an instance can only be set by itself. 
