### PR TITLE
Add apache conf variable filler script

### DIFF
--- a/linux/opt/sage/bin/apache_conf_rewrite.sh
+++ b/linux/opt/sage/bin/apache_conf_rewrite.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+. /opt/sage/bin/instance_env_vars.sh  && sed -i "s/EC2_INSTANCE_ID/$EC2_INSTANCE_ID/g" /etc/apache2/sites-available/proxy.conf
+systemctl restart apache2


### PR DESCRIPTION
This is a simple script to insert the instanceid variable in a specific apache config; this variable becomes part of an apache route that allows us to use a single load balancer for many scientific computing notebook instances.