### PR TITLE
Handle cfn updates

### DIFF
--- a/linux/opt/sage/bin/apache_conf_rewrite.sh
+++ b/linux/opt/sage/bin/apache_conf_rewrite.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-. /opt/sage/bin/instance_env_vars.sh  && sed -i "s/EC2_INSTANCE_ID/$EC2_INSTANCE_ID/g" /etc/apache2/sites-available/proxy.conf
+. /opt/sage/bin/instance_env_vars.sh  && sed -i "s/^.*<LocationMatch.*\/.*\/>.*$/<LocationMatch \/$EC2_INSTANCE_ID\/>/g" /etc/apache2/sites-available/proxy.conf
 systemctl restart apache2


### PR DESCRIPTION
This changes the sed regex to rewrite a line in the Apache proxy config at any point, and so can be used again after a cfn update.