### PR TITLE
[SC-383] Updates for aws cli v2

### DIFF
--- a/linux/opt/sage/bin/apply_name_tag.sh
+++ b/linux/opt/sage/bin/apply_name_tag.sh
@@ -4,6 +4,6 @@
 
 source /opt/sage/bin/instance_env_vars.sh
 
-/usr/bin/aws ec2 create-tags --region $AWS_REGION \
+/usr/local/bin/aws ec2 create-tags --region $AWS_REGION \
   --resources $EC2_INSTANCE_ID \
   --tags Key=Name,Value=$PRODUCT_NAME Key=OwnerEmail,Value=$OWNER_EMAIL Key='Protected/AccessApprovedCaller',Value=$ACCESS_APPROVED_ROLEID:$OIDC_USER_ID

--- a/linux/opt/sage/bin/make_env_vars_file.sh
+++ b/linux/opt/sage/bin/make_env_vars_file.sh
@@ -17,7 +17,7 @@ if [[ -z "$AWS_REGION" || -z "$STACK_ID" || -z "$STACK_NAME" ]]; then
 fi
 
 EC2_INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)
-ROOT_DISK_ID=$(/usr/bin/aws ec2 describe-volumes \
+ROOT_DISK_ID=$(/usr/local/bin/aws ec2 describe-volumes \
   --region "$AWS_REGION" \
   --filters Name=attachment.instance-id,Values="$EC2_INSTANCE_ID" \
   --query Volumes[].VolumeId --out text)
@@ -35,7 +35,7 @@ PROVISIONING_PRINCIPAL_ARN=$(extract_tag_value 'aws:servicecatalog:provisioningP
 PRINCIPAL_ID=${PROVISIONING_PRINCIPAL_ARN##*/}  #Immutable Synapse userid derived from assume-role session name
 ASSUMED_ROLE_NAME=$(cut -d'/' -f2 <<< ${PROVISIONING_PRINCIPAL_ARN}) # the SC end user assumed role name
 # the SC end user assumed role ID
-ACCESS_APPROVED_ROLEID=$(/usr/bin/aws --region $AWS_REGION \
+ACCESS_APPROVED_ROLEID=$(/usr/local/bin/aws --region $AWS_REGION \
   iam get-role --query Role.RoleId --out text --role-name ${ASSUMED_ROLE_NAME})
 
 if [[ "$PRINCIPAL_ID" =~ [[:digit:]] ]]; then
@@ -54,7 +54,7 @@ else
 fi
 
 RESOURCE_ID=${STACK_ID##*/}
-PRODUCTS=$(/usr/bin/aws --region $AWS_REGION \
+PRODUCTS=$(/usr/local/bin/aws --region $AWS_REGION \
   servicecatalog search-provisioned-products \
   --filters SearchQuery=$RESOURCE_ID )
 NUM_PRODUCTS=$(echo $PRODUCTS | jq -r '.TotalResultsCount')

--- a/linux/opt/sage/bin/make_env_vars_file.sh
+++ b/linux/opt/sage/bin/make_env_vars_file.sh
@@ -29,8 +29,6 @@ extract_tag_value() {
   echo "$EC2_INSTANCE_TAGS" | jq -j --arg KEYNAME "$1" '.Tags[] | select(.Key == $KEYNAME).Value '
 }
 
-DEPARTMENT=$(extract_tag_value Department)
-PROJECT=$(extract_tag_value Project)
 PROVISIONING_PRINCIPAL_ARN=$(extract_tag_value 'aws:servicecatalog:provisioningPrincipalArn')
 PRINCIPAL_ID=${PROVISIONING_PRINCIPAL_ARN##*/}  #Immutable Synapse userid derived from assume-role session name
 ASSUMED_ROLE_NAME=$(cut -d'/' -f2 <<< ${PROVISIONING_PRINCIPAL_ARN}) # the SC end user assumed role name
@@ -74,8 +72,6 @@ export STACK_NAME=$STACK_NAME
 export STACK_ID=$STACK_ID
 export EC2_INSTANCE_ID=$EC2_INSTANCE_ID
 export ROOT_DISK_ID=$ROOT_DISK_ID
-export DEPARTMENT=$DEPARTMENT
-export PROJECT=$PROJECT
 export ASSUMED_ROLE_NAME=$ASSUMED_ROLE_NAME
 export ACCESS_APPROVED_ROLEID=$ACCESS_APPROVED_ROLEID
 export OWNER_EMAIL=$OWNER_EMAIL


### PR DESCRIPTION
We updated the AWS CLI when we moved to using ubuntu 22.0[1] as the base image for the service catalog EC2 products. 

* The AWS CLI v2 is installed into `/usr/local/bin/aws` instead of `/usr/bin/aws`.
* The department and project tags were removed by PR https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/834
 
[1] https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-jammy

