### PR TITLE
SC-383: create dir if not exist

### DIFF
--- a/linux/opt/sage/bin/rstudio_synapse_cred_env.sh
+++ b/linux/opt/sage/bin/rstudio_synapse_cred_env.sh
@@ -15,6 +15,11 @@ EC2_INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/insta
 
 SYNAPSE_TOKEN_AWS_SSM_PARAMETER_NAME="/$SERVICE_CATALOG_PREFIX/$EC2_INSTANCE_ID/$SSM_PARAMETER_SUFFIX"
 
+# create directory if does not exist
+if [ ! -d "/etc/R" ]; then
+  mkdir -p /etc/R
+fi
+
 # set environment variable for R
 echo "SYNAPSE_TOKEN_AWS_SSM_PARAMETER_NAME=$SYNAPSE_TOKEN_AWS_SSM_PARAMETER_NAME" >> /etc/R/Renviron.site
 echo "AWS_DEFAULT_REGION=$AWS_REGION" >> /etc/R/Renviron.site


### PR DESCRIPTION
This PR fixes an issue with deployment of the RStudio Notebook product v1.2.6.
Since R is not installed by apt anymore, the directory '/etc/R' does not exist and causes the configuration of the instance to fail at
`
Aug  1 15:33:05 ip-10-31-25-226 cloud-init[1102]: Error occurred during build: Command 02_write_rstudio_env failed
`
which is
`
02_write_rstudio_env:
              command: "/bin/bash /opt/sage/bin/rstudio_synapse_cred_env.sh"
`
The PR adds the creation of the directory.