### PR TITLE
[SC-409] Upgrade from IMDSv1 to IMDSv2

### DIFF
--- a/linux/opt/sage/bin/apache_conf_rewrite.sh
+++ b/linux/opt/sage/bin/apache_conf_rewrite.sh
@@ -5,6 +5,7 @@
 # notebook gets stripped out before the traffic is received by the notebook web server.
 # We did it this way because the Apache module we use for rewrite did not support regular expressions.
 
-EC2_INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+EC2_INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id)
 sed -i "s/EC2_INSTANCE_ID/$EC2_INSTANCE_ID/g" /etc/apache2/sites-available/proxy.conf
 systemctl restart apache2

--- a/linux/opt/sage/bin/apache_synapse_cred_env.sh
+++ b/linux/opt/sage/bin/apache_synapse_cred_env.sh
@@ -11,7 +11,8 @@
 # In case I am bad at programming
 set -e; set -u; set -o pipefail
 
-EC2_INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+EC2_INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id)
 
 INSTANCE_ID_KEY="$SERVICE_CATALOG_PREFIX/$EC2_INSTANCE_ID"
 

--- a/linux/opt/sage/bin/rstudio_synapse_cred_env.sh
+++ b/linux/opt/sage/bin/rstudio_synapse_cred_env.sh
@@ -10,8 +10,9 @@
 # In case I am bad at programming
 set -e; set -u; set -o pipefail
 
-AWS_REGION=$(/usr/bin/curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | /usr/bin/jq -r .region)
-EC2_INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+EC2_INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id)
+AWS_REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
 
 SYNAPSE_TOKEN_AWS_SSM_PARAMETER_NAME="/$SERVICE_CATALOG_PREFIX/$EC2_INSTANCE_ID/$SSM_PARAMETER_SUFFIX"
 


### PR DESCRIPTION
Testing the Amazon Linux 2023 image in scipool-dev is failing because the EC2 instance created by Service Catalog requires IMDSv2, and an empty response from IMDSv1 is causing this script to fail.

Follow the user guide [1] to make a request to IMDSv2 instead, and rely on the PATH environment variable for looking up the location of executables since Amazon Linux 2023 pre-installs aws-cli under `/usr/bin`.

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
